### PR TITLE
Display alternative names

### DIFF
--- a/src/lib-network/netlink/netlink.c
+++ b/src/lib-network/netlink/netlink.c
@@ -92,7 +92,8 @@ int rtnl_message_parse_rtattr(struct rtattr **tb, int max, struct rtattr *rta, i
         unsigned short type;
 
         while (RTA_OK(rta, len)) {
-                type = rta->rta_type;
+                type = rta->rta_type & ~NLA_F_NESTED;
+
                 if ((type <= max) && (tb + type))
                         *(tb + type) = rta;
 

--- a/src/lib-network/netlink/netlink.h
+++ b/src/lib-network/netlink/netlink.h
@@ -15,6 +15,10 @@
 
 #define NLMSG_TAIL(nmsg) ((struct rtattr *) (((char *) (nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
 
+#ifndef IFLA_PROP_LIST
+#define IFLA_PROP_LIST 52
+#endif
+
 int rtnl_message_add_attribute(struct nlmsghdr *hdr, int type, const void *value, int len);
 struct rtattr *rtnl_message_add_attribute_nested(struct nlmsghdr *hdr, int type, const void *value, int len);
 int addattr_nest_end(struct nlmsghdr *hdr, struct rtattr *nested);

--- a/src/manager/network-link.c
+++ b/src/manager/network-link.c
@@ -152,6 +152,27 @@ static int fill_one_link_info(struct nlmsghdr *h, size_t len, Link **ret) {
                 n->contains_mac_address = true;
         }
 
+        if (rta_tb[IFLA_PROP_LIST]) {
+                struct rtattr *i, *j = rta_tb[IFLA_PROP_LIST];
+                _auto_cleanup_strv_ char **s = NULL;
+                int k = RTA_PAYLOAD(j);
+
+                for (i = RTA_DATA(j); RTA_OK(i, k); i = RTA_NEXT(i, k)) {
+                        if (!s) {
+                                s = strv_new((char *) RTA_DATA(i));
+                                if (!s)
+                                        return -ENOMEM;
+                        } else {
+                                r = strv_add(&s, (char *) RTA_DATA(i));
+                                if (r < 0)
+                                        return r;
+                        }
+
+                }
+
+                n->alt_names = steal_pointer(s);
+        }
+
         *ret = steal_pointer(n);
 
         return 0;

--- a/src/manager/network-link.h
+++ b/src/manager/network-link.h
@@ -23,6 +23,7 @@ typedef struct Link {
         uint8_t operstate;
         struct ether_addr mac_address;
         uint32_t mtu;
+        char **alt_names;
 
         bool contains_mac_address:1;
         bool contains_mtu:1;
@@ -31,6 +32,11 @@ typedef struct Link {
 typedef struct Links {
          GList *links;
 } Links;
+
+static inline void link_free_one(Link **l) {
+        strv_free((*l)->alt_names);
+        free(*l);
+}
 
 static inline void links_free(Links **l) {
         if (l && *l) {

--- a/src/manager/network-manager-ctl.c
+++ b/src/manager/network-manager-ctl.c
@@ -245,7 +245,6 @@ static int list_one_link(char *argv[]) {
          (void)  display_one_link_udev(l, true, NULL);
          list_link_sysfs_attributes(l);
 
-
          if (l->alt_names) {
                  char **j;
 
@@ -1138,7 +1137,7 @@ _public_ int ncm_add_dns_domains(int argc, char *argv[]) {
                 }
         }
 
-        r = argv_to_strv(argc - 1, argv + 1, &domains);
+        r = argv_to_strv(argc - 2, argv + 2, &domains);
         if (r < 0) {
                 log_warning("Failed to parse domains addresses: %s", g_strerror(-r));
                 return r;
@@ -1334,7 +1333,7 @@ _public_ int ncm_link_add_ntp(int argc, char *argv[]) {
                return -errno;
        }
 
-       r = argv_to_strv(argc - 1, argv + 1, &ntps);
+       r = argv_to_strv(argc - 2, argv + 2, &ntps);
        if (r < 0) {
                log_warning("Failed to parse NTP addresses: %s", g_strerror(-r));
                return r;

--- a/src/manager/network-manager-ctl.c
+++ b/src/manager/network-manager-ctl.c
@@ -112,7 +112,7 @@ static void list_one_link_addresses(gpointer key, gpointer value, gpointer userd
                 printf("%s", c);
                 first = false;
         } else
-                printf("                  %s", c);
+                printf("                   %s", c);
 
         r = network_parse_link_dhcp4_addresses(a->ifindex, &dhcp);
         if (r >= 0 && strv_contains((const char **) dhcp, c))
@@ -156,17 +156,17 @@ static int display_one_link_udev(Link *l, bool display, char **link_file) {
                 return 0;
 
         if (path)
-                printf("            %sPath%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), path);
+                printf("             %sPath%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), path);
         if (driver)
-                printf("          %sDriver%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), driver);
+                printf("           %sDriver%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), driver);
         if (vendor)
-                printf("          %sVendor%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), vendor);
+                printf("           %sVendor%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), vendor);
         if (model)
-                printf("           %sModel%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), model);
+                printf("            %sModel%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), model);
 
         hwdb_get_manufacturer((uint8_t *) &l->mac_address.ether_addr_octet, &manufacturer);
         if (manufacturer)
-                printf("    %sManufacturer%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), manufacturer);
+                printf("     %sManufacturer%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), manufacturer);
 
         udev_device_unref(dev);
         udev_unref(udev);
@@ -183,14 +183,14 @@ static void list_link_sysfs_attributes(Link *l) {
         (void) link_read_sysfs_attribute(l->name, "mtu", &mtu);
 
         if (ether)
-                printf("      %sHW Address%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), ether);
+                printf("       %sHW Address%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), ether);
         if (mtu)
-                printf("             %sMTU%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), mtu);
+                printf("              %sMTU%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), mtu);
 
         if (duplex)
-                printf("          %sDuplex%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), duplex);
+                printf("           %sDuplex%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), duplex);
         if (speed)
-                printf("           %sSpeed%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), speed);
+                printf("            %sSpeed%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), speed);
 }
 
 static int list_one_link(char *argv[]) {
@@ -200,7 +200,7 @@ static int list_one_link(char *argv[]) {
         _cleanup_(addresses_unref) Addresses *addr = NULL;
         _cleanup_(routes_free) Routes *route = NULL;
         _auto_cleanup_ IfNameIndex *p = NULL;
-        _auto_cleanup_ Link *l = NULL;
+        _cleanup_(link_free_one) Link *l = NULL;
         int r;
 
         r = parse_ifname_or_index(*argv, &p);
@@ -232,10 +232,10 @@ static int list_one_link(char *argv[]) {
 
         (void) network_parse_link_network_file(l->ifindex, &network);
         (void)  display_one_link_udev(l, false, &link);
-         printf("       %sLink File%s: %s\n"
-                "    %sNetwork File%s: %s\n"
-                "            %sType%s: %s\n"
-                "           %sState%s: %s%s%s %s(%s)%s\n",
+         printf("        %sLink File%s: %s\n"
+                "     %sNetwork File%s: %s\n"
+                "             %sType%s: %s\n"
+                "            %sState%s: %s%s%s %s(%s)%s\n",
                 ansi_color_bold_cyan(), ansi_color_reset(), string_na(link),
                 ansi_color_bold_cyan(), ansi_color_reset(), string_na(network),
                 ansi_color_bold_cyan(), ansi_color_reset(), string_na(arphrd_to_name(l->iftype)),
@@ -245,9 +245,19 @@ static int list_one_link(char *argv[]) {
          (void)  display_one_link_udev(l, true, NULL);
          list_link_sysfs_attributes(l);
 
+
+         if (l->alt_names) {
+                 char **j;
+
+                 printf("%sAlternative names%s: ", ansi_color_bold_cyan(), ansi_color_reset());
+                 strv_foreach(j, l->alt_names)
+                         printf("%s ", *j);
+                 printf("\n");
+         }
+
          r = manager_get_one_link_address(l->ifindex, &addr);
          if (r >= 0 && addr && set_size(addr->addresses) > 0) {
-                 printf("         %sAddress%s: ", ansi_color_bold_cyan(), ansi_color_reset());
+                 printf("          %sAddress%s: ", ansi_color_bold_cyan(), ansi_color_reset());
                  set_foreach(addr->addresses, list_one_link_addresses, NULL);
          }
 
@@ -256,7 +266,7 @@ static int list_one_link(char *argv[]) {
                  bool first = true;
                  GList *i;
 
-                 printf("         %sGateway%s: ", ansi_color_bold_cyan(), ansi_color_reset());
+                 printf("          %sGateway%s: ", ansi_color_bold_cyan(), ansi_color_reset());
                  for (i = route->routes; i; i = i->next) {
                          _auto_cleanup_ char *c = NULL;
                          Route *a = NULL;
@@ -278,7 +288,7 @@ static int list_one_link(char *argv[]) {
                  if (!s)
                          return log_oom();
 
-                 printf("             %sDNS%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), s);
+                 printf("              %sDNS%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), s);
          }
 
          if (search_domains) {
@@ -288,7 +298,7 @@ static int list_one_link(char *argv[]) {
                  if (!s)
                          return log_oom();
 
-                 printf("  %sSearch Domains%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), s);
+                 printf("   %sSearch Domains%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), s);
         }
 
          if (route_domains) {
@@ -298,7 +308,7 @@ static int list_one_link(char *argv[]) {
                  if (!s)
                          return log_oom();
 
-                 printf("             %sRoute Domains%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), s);
+                 printf("              %sRoute Domains%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), s);
          }
 
          if (ntp) {
@@ -308,12 +318,12 @@ static int list_one_link(char *argv[]) {
                  if (!s)
                          return log_oom();
 
-                 printf("             %sNTP%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), s);
+                 printf("              %sNTP%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), s);
          }
 
          (void) network_parse_link_timezone(l->ifindex, &tz);
          if (tz)
-                 printf("       %sTime Zone%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), tz);
+                 printf("        %sTime Zone%s: %s\n", ansi_color_bold_cyan(), ansi_color_reset(), tz);
 
         return 0;
 }

--- a/src/share/string-util.c
+++ b/src/share/string-util.c
@@ -105,8 +105,8 @@ char **strv_new(char *x) {
          if (!a)
                  return NULL;
 
-         a[1] = g_strdup(x);
-         if (!a[1])
+         a[0] = g_strdup(x);
+         if (!a[0])
                  return NULL;
 
          return steal_pointer(a);


### PR DESCRIPTION
```
❯ build/nmctl show ens33                                                                                                                                         display-alternative-names 
        Link File: /usr/lib/systemd/network/99-default.link
     Network File: /usr/lib/systemd/network/ens33.network
             Type: ether
            State: routable (configured)
             Path: pci-0000:02:01.0
           Driver: pcnet32
           Vendor: Advanced Micro Devices, Inc. [AMD]
            Model: 79c970 [PCnet32 LANCE] (PCnet - Fast 79C971)
     Manufacturer: VMware, Inc.
       HW Address: 00:0c:29:77:f8:a9
              MTU: 1500
           Duplex: half
            Speed: 10
Alternative names: enp2s1  <==========
          Address: fe80::20c:29ff:fe77:f8a9/64
                   172.16.85.235/24
          Gateway: 172.16.85.2
              DNS: 172.16.85.2
```