### PR TITLE
netdev : introduce macvlan

### DIFF
--- a/include/network-config-manager.h.in
+++ b/include/network-config-manager.h.in
@@ -72,6 +72,7 @@ int ncm_create_vlan(int argc, char *argv[]);
 int ncm_create_bridge(int argc, char *argv[]);
 int ncm_create_bond(int argc, char *argv[]);
 int ncm_create_vxlan(int argc, char *argv[]);
+int ncm_create_macvlan(int argc, char *argv[]);
 
 int ncm_system_status(int argc, char *argv[]);
 bool ncm_is_netword_running(void);

--- a/src/manager/netdev.h
+++ b/src/manager/netdev.h
@@ -1,8 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0
  * Copyright © 2020 VMware, Inc.
  */
-
 #pragma once
+
+#include <linux/if_link.h>
 
 #include "network-util.h"
 
@@ -11,6 +12,7 @@ typedef enum NetDevKind {
         NET_DEV_KIND_BRIDGE,
         NET_DEV_KIND_BOND,
         NET_DEV_KIND_VXLAN,
+        NET_DEV_KIND_MACVLAN,
         _NET_DEV_KIND_MAX,
         _NET_DEV_KIND_INVALID = -1
 } NetDevKind;
@@ -27,6 +29,16 @@ typedef enum BondMode {
         _BOND_MODE_INVALID = -1
 } BondMode;
 
+typedef enum MACVLanMode {
+        MAC_VLAN_MODE_PRIVATE  = MACVLAN_MODE_PRIVATE,
+        MAC_VLAN_MODE_VEPA     = MACVLAN_MODE_VEPA,
+        MAC_VLAN_MODE_BRIDGE   = MACVLAN_MODE_BRIDGE,
+        MAC_VLAN_MODE_PASSTHRU = MACVLAN_MODE_PASSTHRU,
+        MAC_VLAN_MODE_SOURCE   = MACVLAN_MODE_SOURCE,
+        _MAC_VLAN_MODE_MAX,
+        _MAC_VLAN_MODE_INVALID = -1
+} MACVLanMode;
+
 typedef struct NetDev {
         char *ifname;
         char *mac;
@@ -42,6 +54,7 @@ typedef struct NetDev {
         uint32_t id;
         NetDevKind kind;
         BondMode bond_mode;
+        MACVLanMode macvlan_mode;
 } NetDev;
 
 int netdev_new(NetDev **ret);
@@ -51,7 +64,10 @@ int generate_netdev_config(NetDev *n, GString **ret);
 int create_netdev_conf_file(const char *ifnameidx, char **ret);
 
 const char *netdev_kind_to_name(NetDevKind id);
-int netdev_kind_to_id(const char *name);
+int netdev_name_to_kind(const char *name);
 
 const char *bond_mode_to_name(BondMode id);
-int bond_mode_to_id(const char *name);
+int bond_name_to_mode(const char *name);
+
+const char *macvlan_mode_to_name(MACVLanMode id);
+int macvlan_name_to_mode(const char *name);

--- a/src/manager/network-config-manager.c
+++ b/src/manager/network-config-manager.c
@@ -1781,17 +1781,17 @@ _public_ int ncm_create_bridge(int argc, char *argv[]) {
 
 _public_ int ncm_create_bond(int argc, char *argv[]) {
         _auto_cleanup_strv_ char **links = NULL;
-        bool k = false;
+        bool have_mode = false;
         BondMode mode;
         int r;
 
         if (string_equal(argv[2], "mode")) {
-                r = bond_mode_to_id(argv[3]);
+                r = bond_name_to_mode(argv[3]);
                 if (r < 0) {
                         log_warning("Failed to parse bond mode '%s' : %s", argv[3], g_strerror(EINVAL));
                         return r;
                 }
-                k = true;
+                have_mode = true;
                 mode = r;
         }
 
@@ -1801,14 +1801,43 @@ _public_ int ncm_create_bond(int argc, char *argv[]) {
                 return r;
         }
 
-        if (!k) {
+        if (!have_mode) {
                 log_warning("Missing Bond mode: %s", g_strerror(EINVAL));
                 return -EINVAL;
         }
 
         r = manager_create_bond(argv[1], mode, links);
         if (r < 0) {
-                log_warning("Failed to create bridge '%s': %s", argv[1], g_strerror(-r));
+                log_warning("Failed to create bond '%s': %s", argv[1], g_strerror(-r));
+                return r;
+        }
+
+        return 0;
+}
+
+_public_ int ncm_create_macvlan(int argc, char *argv[]) {
+        bool have_mode = false;
+        MACVLanMode mode;
+        int r;
+
+        if (string_equal(argv[2], "mode")) {
+                r = macvlan_name_to_mode(argv[3]);
+                if (r < 0) {
+                        log_warning("Failed to parse macvlan mode '%s' : %s", argv[3], g_strerror(EINVAL));
+                        return r;
+                }
+                have_mode = true;
+                mode = r;
+        }
+
+        if (!have_mode) {
+                log_warning("Missing MACVLan mode: %s", g_strerror(EINVAL));
+                return -EINVAL;
+        }
+
+        r = manager_create_macvlan(argv[1], mode);
+        if (r < 0) {
+                log_warning("Failed to create macvlan '%s': %s", argv[1], g_strerror(-r));
                 return r;
         }
 
@@ -1817,7 +1846,7 @@ _public_ int ncm_create_bond(int argc, char *argv[]) {
 
 _public_ int ncm_create_vxlan(int argc, char *argv[]) {
         _auto_cleanup_ IPAddress *local = NULL, *remote = NULL, *group = NULL;
-        bool independent = false, vni = false;
+        bool independent = false, have_vni = false;
         _auto_cleanup_ IfNameIndex *p = NULL;
         uint16_t port;
         uint32_t vni;
@@ -1842,7 +1871,7 @@ _public_ int ncm_create_vxlan(int argc, char *argv[]) {
                                 return r;
                         }
 
-                        vni = true;
+                        have_vni = true;
                         continue;
                 }
 
@@ -1902,7 +1931,7 @@ _public_ int ncm_create_vxlan(int argc, char *argv[]) {
                 }
         }
 
-        if (!vni) {
+        if (!have_vni) {
                 log_warning("Missing VxLan vni: %s", g_strerror(EINVAL));
                 return -EINVAL;
         }
@@ -1918,7 +1947,7 @@ _public_ int ncm_create_vxlan(int argc, char *argv[]) {
 
 _public_ int ncm_create_vlan(int argc, char *argv[]) {
         _auto_cleanup_ IfNameIndex *p = NULL;
-        bool k = false;
+        bool have_id = false;
         uint16_t id;
         int r;
 
@@ -1934,10 +1963,10 @@ _public_ int ncm_create_vlan(int argc, char *argv[]) {
                         log_warning("Failed to parse VLAN id '%s' for link '%s': %s", argv[3], argv[4], g_strerror(EINVAL));
                         return r;
                 }
-                k = true;
+                have_id = true;
         }
 
-        if (!vni) {
+        if (!have_id) {
                 log_warning("Missing Vlan id: %s", g_strerror(EINVAL));
                 return -EINVAL;
         }

--- a/src/manager/network-manager-ctl.c
+++ b/src/manager/network-manager-ctl.c
@@ -164,6 +164,7 @@ static int help(void) {
                                                      "\n\t\t\t\t\t\t [LINK] [LINK] ... Creates bond netdev and sets master to device\n"
                "  create-vxlan                 [dev LINK] [VXLAN name] vni [INTEGER] [local ADDRESS] [remote ADDRESS] [port PORT] [independent { yes | no | on | off | 1 | 0}]"
                                                       "\n\t\t\t\t\t\t  Creates vxlan netdev\n"
+               "  create-macvlan               [MACVLAN name] mode [MODE {private | vepa | bridge | passthru | source}]\n"
                "  reload                              Reload .network and .netdev files.\n"
                "  reconfigure                  [LINK] Reconfigure Link.\n"
                "  generate-config-from-yaml    [FILE] Generates network file configuration from yaml file.\n"
@@ -277,6 +278,7 @@ static int cli_run(int argc, char *argv[]) {
                 { "create-bridge",                2,        WORD_ANY, false, ncm_create_bridge },
                 { "create-bond",                  5,        WORD_ANY, false, ncm_create_bond },
                 { "create-vxlan",                 2,        WORD_ANY, false, ncm_create_vxlan },
+                { "create-macvlan",               2,        WORD_ANY, false, ncm_create_macvlan },
                 { "reload",                       WORD_ANY, WORD_ANY, false, ncm_network_reload },
                 { "reconfigure",                  1,        WORD_ANY, false, ncm_link_reconfigure },
                 { "generate-config-from-yaml",    1,        WORD_ANY, false, generate_networkd_config_from_yaml },

--- a/src/manager/network-manager.c
+++ b/src/manager/network-manager.c
@@ -1393,3 +1393,60 @@ int manager_create_vxlan(const char *vxlan,
 
         return dbus_network_reload();
 }
+
+int manager_create_macvlan(const char *macvlan, MACVLanMode mode) {
+        _cleanup_(g_string_unrefp) GString *netdev_config = NULL, *macvlan_network_config = NULL;
+        _auto_cleanup_ char *macvlan_netdev = NULL, *macvlan_network = NULL;
+        _cleanup_(netdev_unrefp) NetDev *netdev = NULL;
+        _cleanup_(network_unrefp) Network *v = NULL;
+        int r;
+
+        assert(macvlan);
+
+        r = netdev_new(&netdev);
+        if (r < 0)
+                return log_oom();
+
+        *netdev = (NetDev) {
+                .ifname = strdup(macvlan),
+                .kind = NET_DEV_KIND_MACVLAN,
+                .macvlan_mode = mode,
+        };
+        if (!netdev->ifname)
+                return log_oom();
+
+        r = create_netdev_conf_file(macvlan, &macvlan_netdev);
+        if (r < 0)
+                return r;
+
+        r = generate_netdev_config(netdev, &netdev_config);
+        if (r < 0)
+                return r;
+
+        r = manager_write_netdev_config(netdev, netdev_config);
+        if (r < 0)
+                return r;
+
+        r = network_new(&v);
+        if (r < 0)
+                return r;
+
+        v->ifname = strdup(macvlan);
+        if (!v->ifname)
+                return log_oom();
+
+        r = generate_network_config(v, &macvlan_network_config);
+        if (r < 0) {
+                log_warning("Failed to generate network configs : %s", g_strerror(-r));
+                return r;
+        }
+
+        r = create_network_conf_file(macvlan, &macvlan_network);
+        if (r < 0)
+                return r;
+
+        (void) manager_write_network_config(v, macvlan_network_config);
+
+
+        return dbus_network_reload();
+}

--- a/src/manager/network-manager.h
+++ b/src/manager/network-manager.h
@@ -60,3 +60,5 @@ int manager_create_bond(const char *bond, BondMode mode, char **interfaces);
 int manager_create_vxlan(const char *vxlan, uint32_t vni, IPAddress *local,
                          IPAddress *remote, IPAddress *group, uint16_t port,
                          const char *dev, bool independent);
+
+int manager_create_macvlan(const char *macvlan, MACVLanMode mode);


### PR DESCRIPTION
```
ork-config-manager-tests.py

==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.0, pytest-6.0.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /run/network-config-manager-ci
collected 56 items

../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNetworkConfigManagerYAML::test_basic_dhcp PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNetworkConfigManagerYAML::test_dhcp_client_identifier PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNetworkConfigManagerYAML::test_network_and_dhcp4_section PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNetworkConfigManagerYAML::test_network_and_dhcp6_section PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNetworkConfigManagerYAML::test_network_static_configuration SKIPPED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNetworkConfigManagerYAML::test_network_static_route_configuration PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestKernelCommandLine::test_network_kernel_command_line_ip_dhcp SKIPPED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestKernelCommandLine::test_network_kernel_command_line_multiple_ip_dhcp SKIPPED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestKernelCommandLine::test_network_kernel_command_line_ip_static SKIPPED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_mtu PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_mac PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_dhcp_type PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_dhcp_iaid PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_add_static_address PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_add_default_gateway PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_add_route PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_add_dns PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_add_domain PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_add_ntp PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_ntp PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_ip_v6_router_advertisement PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_link_local_addressing PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_ipv4_link_local_route PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_llmnr PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_multicast_dns PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_ip_masquerade PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_dhcp4_client_identifier PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_dhcp4_use_dns PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_dhcp4_use_mtu PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_dhcp4_use_domains PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_dhcp4_use_ntp PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_dhcp4_use_routes PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_link_lldp PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetwork::test_cli_set_link_emit_lldp PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetDev::test_cli_create_vlan PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetDev::test_cli_create_vxlan PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetDev::test_cli_create_bridge PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestCLINetDev::test_cli_create_bond PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestWifiWPASupplicantConf::test_wifi_wpa_supplicant_name_password_dhcp PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestWifiWPASupplicantConf::test_wifi_wpa_supplicant_name_password_static PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestWifiWPASupplicantConf::test_wifi_wpa_supplicant_eap_tls_dhcp SKIPPED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestWifiWPASupplicantConf::test_wifi_wpa_supplicant_eap_ttls_dhcp PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_add_chain table ip testtable99 {
	chain testchain99 {
	}
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_add_rule_tcp_accept Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
table ip testtable99 {
	chain testchain99 {
		tcp dport 9999 counter packets 0 bytes 0 accept
	}
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_add_rule_tcp_drop Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
table ip testtable99 {
	chain testchain99 {
		tcp dport 9999 counter packets 0 bytes 0 drop
	}
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_add_rule_tcp_drop_accept_sport Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
table ip testtable99 {
	chain testchain99 {
		tcp sport 9999 counter packets 0 bytes 0 accept
	}
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_add_rule_tcp_drop_sport Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
table ip testtable99 {
	chain testchain99 {
		tcp sport 9999 counter packets 0 bytes 0 drop
	}
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_add_rule_udp_accept_dport Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
table ip testtable99 {
	chain testchain99 {
		udp dport 9999 counter packets 0 bytes 0 accept
	}
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_add_rule_udp_accept_sport Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
table ip testtable99 {
	chain testchain99 {
		udp sport 9999 counter packets 0 bytes 0 accept
	}
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_add_rule_udp_drop_dport Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
table ip testtable99 {
	chain testchain99 {
		udp dport 9999 counter packets 0 bytes 0 drop
	}
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_add_table table inet firewalld
table ip firewalld
table ip6 firewalld
table ip testtable99
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_delete_chain Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
table ip testtable99 {
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_delete_rule Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
table ip testtable99 {
	chain testchain99 {
		udp dport 9999 counter packets 0 bytes 0 accept
	}
}
table ip testtable99 {
	chain testchain99 {
	}
}
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_delete_table table inet firewalld
table ip firewalld
table ip6 firewalld
table ip testtable99
table inet firewalld
table ip firewalld
table ip6 firewalld
Error: Could not process rule: No such file or directory
delete table testtable99
             ^^^^^^^^^^^
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_show_chain Family  Tables   Chains
ipv4  : firewalld nat_PREROUTING
ipv4  : firewalld nat_PREROUTING_POLICIES_pre
ipv4  : firewalld nat_PREROUTING_ZONES
ipv4  : firewalld nat_PREROUTING_POLICIES_post
ipv4  : firewalld nat_POSTROUTING
ipv4  : firewalld nat_POSTROUTING_POLICIES_pre
ipv4  : firewalld nat_POSTROUTING_ZONES
ipv4  : firewalld nat_POSTROUTING_POLICIES_post
ipv4  : firewalld nat_POST_FedoraWorkstation
ipv4  : firewalld nat_POST_FedoraWorkstation_pre
ipv4  : firewalld nat_POST_FedoraWorkstation_log
ipv4  : firewalld nat_POST_FedoraWorkstation_deny
ipv4  : firewalld nat_POST_FedoraWorkstation_allow
ipv4  : firewalld nat_POST_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_FedoraWorkstation
ipv4  : firewalld nat_PRE_FedoraWorkstation_pre
ipv4  : firewalld nat_PRE_FedoraWorkstation_log
ipv4  : firewalld nat_PRE_FedoraWorkstation_deny
ipv4  : firewalld nat_PRE_FedoraWorkstation_allow
ipv4  : firewalld nat_PRE_FedoraWorkstation_post
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_pre
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_log
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_deny
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_allow
ipv4  : firewalld nat_PRE_policy_allow-host-ipv6_post
ipv4  : firewalld nat_POST_libvirt
ipv4  : firewalld nat_POST_libvirt_pre
ipv4  : firewalld nat_POST_libvirt_log
ipv4  : firewalld nat_POST_libvirt_deny
ipv4  : firewalld nat_POST_libvirt_allow
ipv4  : firewalld nat_POST_libvirt_post
ipv4  : firewalld nat_PRE_libvirt
ipv4  : firewalld nat_PRE_libvirt_pre
ipv4  : firewalld nat_PRE_libvirt_log
ipv4  : firewalld nat_PRE_libvirt_deny
ipv4  : firewalld nat_PRE_libvirt_allow
ipv4  : firewalld nat_PRE_libvirt_post
ipv4  : testtable99 testchain99
PASSED
../../../../../run/network-config-manager-ci/network-config-manager-tests.py::TestNFTable::test_nmctl_show_table Family   Tables
ip    :  firewalld
ipv4  :  firewalld
ipv6  :  firewalld
ipv4  :  testtable99
PASSED

========================================================================= 51 passed, 5 skipped in 314.29s (0:05:14) ==========================================================================

~/tt/ncm/netdev  macvlan* 5m 15s

```