### PR TITLE
Add support to display proxy settings

### DIFF
--- a/include/network-config-manager.h.in
+++ b/include/network-config-manager.h.in
@@ -96,6 +96,7 @@ int ncm_link_show_network_config(int argc, char *argv[]);
 int ncm_link_edit_network_config(int argc, char *argv[]);
 
 int ncm_configure_proxy(int argc, char *argv[]);
+int ncm_show_proxy(int argc, char *argv[]);
 
 int ncm_system_status(int argc, char *argv[]);
 bool ncm_is_netword_running(void);

--- a/include/network-config-manager.h.in
+++ b/include/network-config-manager.h.in
@@ -97,6 +97,7 @@ int ncm_link_edit_network_config(int argc, char *argv[]);
 
 int ncm_configure_proxy(int argc, char *argv[]);
 int ncm_show_proxy(int argc, char *argv[]);
+int ncm_get_proxy(char ***proxy);
 
 int ncm_system_status(int argc, char *argv[]);
 bool ncm_is_netword_running(void);

--- a/src/manager/network-config-manager.c
+++ b/src/manager/network-config-manager.c
@@ -3432,6 +3432,54 @@ _public_ int ncm_configure_proxy(int argc, char *argv[]) {
           return 0;
 }
 
+_public_ int ncm_show_proxy(int argc, char *argv[]) {
+        _auto_cleanup_hash_ GHashTable *table = NULL;
+        char *v;
+        int r;
+
+        r = manager_parse_proxy_config(&table);
+        if (r < 0) {
+                log_warning("Failed to parse proxy settings: %s", g_strerror(-r));
+                return r;
+        }
+
+        printf("%sProxy Settings %s\n", ansi_color_blue_header(), ansi_color_reset());
+
+        v = g_hash_table_lookup(table, "PROXY_ENABLED");
+        if(v)
+                printf("      Enabled: %s\n", (char *) v);
+
+        v = g_hash_table_lookup(table, "HTTP_PROXY");
+        if(v)
+                printf("         HTTP: %s\n", (char *) v);
+
+        v = g_hash_table_lookup(table, "HTTPS_PROXY");
+        if(v)
+                printf("        HTTPS: %s\n", (char *) v);
+
+        v = g_hash_table_lookup(table, "FTP_PROXY");
+        if(v)
+                printf("          FTP: %s\n", (char *) v);
+
+        v = g_hash_table_lookup(table, "GOPHER_PROXY");
+        if(v)
+                printf("       Gopher: %s\n", (char *) v);
+
+        v = g_hash_table_lookup(table, "SOCKS_PROXY");
+        if(v)
+                printf("        Socks: %s\n", (char *) v);
+
+        v = g_hash_table_lookup(table, "SOCKS5_SERVER");
+        if(v)
+                printf("Socks5 Server: %s\n", (char *) v);
+
+        v = g_hash_table_lookup(table, "NO_PROXY");
+        if(v)
+                printf("     No Proxy: %s\n", (char *) v);
+
+        return 0;
+}
+
 _public_ bool ncm_is_netword_running(void) {
         if (access("/run/systemd/netif/state", F_OK) < 0) {
                 log_warning("systemd-networkd is not running. Failed to continue.\n\n");

--- a/src/manager/network-config-manager.c
+++ b/src/manager/network-config-manager.c
@@ -3307,9 +3307,23 @@ _public_ int ncm_link_edit_network_config(int argc, char *argv[]) {
 
 _public_ int ncm_configure_proxy(int argc, char *argv[]) {
         _auto_cleanup_  char *http = NULL, *https = NULL, *ftp = NULL, *gopher = NULL, *socks = NULL, *socks5 = NULL, *no_proxy = NULL;
-        int r;
+        int r, enable = -1;
 
         for (int i = 1; i < argc; i++) {
+                if (string_equal(argv[i], "enable")) {
+                        parse_next_arg(argv, argc, i);
+                        i++;
+
+                        r = parse_boolean(argv[i]);
+                        if (r < 0) {
+                                log_warning("Failed to parse enable '%s': %s", argv[i], g_strerror(-r));
+                                return r;
+                        }
+
+                        enable = r;
+                        continue;
+                }
+
                 if (string_equal(argv[i], "http") || string_equal(argv[i], "none")) {
                         parse_next_arg(argv, argc, i);
                         i++;
@@ -3409,7 +3423,7 @@ _public_ int ncm_configure_proxy(int argc, char *argv[]) {
                 }
         }
 
-        r = manager_configure_proxy(http, https, ftp, gopher, socks, socks5, no_proxy);
+        r = manager_configure_proxy(enable, http, https, ftp, gopher, socks, socks5, no_proxy);
         if (r < 0) {
                 log_warning("Failed to configure proxy settings: %s", g_strerror(-r));
                 return r;

--- a/src/manager/network-manager-ctl.c
+++ b/src/manager/network-manager-ctl.c
@@ -207,6 +207,7 @@ static int help(void) {
                "  show-network-config          [LINK] Displays network configuration of link.\n"
                "  edit-network-config          [LINK] Edit network configuration of link.\n"
                "  set-proxy                    [enable {BOOLEAN}] [http|https|ftp|gopher|socks|socks5|noproxy] [CONFIGURATION | none] Configure proxy.\n"
+               "  show-proxy                   Shows proxy configuration.\n"
                "  generate-config-from-yaml    [FILE] Generates network file configuration from yaml file.\n"
                "  apply-yaml-config            Generates network file configuration from yaml files found in /etc/network-config-manager/yaml.\n"
                "  generate-config-from-cmdline [FILE | COMMAND LINE] Generates network file configuration from command kernel command line or command line.\n"
@@ -349,6 +350,7 @@ static int cli_run(int argc, char *argv[]) {
                 { "show-network-config",          1,        WORD_ANY, false, ncm_link_show_network_config },
                 { "edit-network-config",          1,        WORD_ANY, false, ncm_link_edit_network_config },
                 { "set-proxy",                    1,        WORD_ANY, false, ncm_configure_proxy },
+                { "show-proxy",                   WORD_ANY, WORD_ANY, false, ncm_show_proxy },
                 { "generate-config-from-yaml",    1,        WORD_ANY, false, generate_networkd_config_from_yaml },
                 { "apply-yaml-config"           , WORD_ANY, WORD_ANY, false, generate_networkd_config_from_yaml },
                 { "generate-config-from-cmdline", WORD_ANY, WORD_ANY, false, generate_networkd_config_from_command_line },

--- a/src/manager/network-manager-ctl.c
+++ b/src/manager/network-manager-ctl.c
@@ -206,7 +206,7 @@ static int help(void) {
                "  reconfigure                  [LINK] Reconfigure Link.\n"
                "  show-network-config          [LINK] Displays network configuration of link.\n"
                "  edit-network-config          [LINK] Edit network configuration of link.\n"
-               "  set-proxy                    [http|https|ftp|gopher|socks|socks5|noproxy] [CONFIGURATION | none] Configure proxy.\n"
+               "  set-proxy                    [enable {BOOLEAN}] [http|https|ftp|gopher|socks|socks5|noproxy] [CONFIGURATION | none] Configure proxy.\n"
                "  generate-config-from-yaml    [FILE] Generates network file configuration from yaml file.\n"
                "  apply-yaml-config            Generates network file configuration from yaml files found in /etc/network-config-manager/yaml.\n"
                "  generate-config-from-cmdline [FILE | COMMAND LINE] Generates network file configuration from command kernel command line or command line.\n"

--- a/src/manager/network-manager.c
+++ b/src/manager/network-manager.c
@@ -2180,7 +2180,8 @@ int manager_edit_link_network_config(const IfNameIndex *ifnameidx) {
         return 0;
 }
 
-int manager_configure_proxy(const char *http,
+int manager_configure_proxy(int enable,
+                            const char *http,
                             const char *https,
                             const char *ftp,
                             const char *gopher,
@@ -2318,6 +2319,23 @@ int manager_configure_proxy(const char *http,
 
                 steal_pointer(s);
                 steal_pointer(k);
+        }
+
+        if (enable != -1) {
+                _auto_cleanup_ char *p = NULL, *t = NULL;
+
+                t = strdup(bool_to_string(enable));
+                if (!t)
+                        return log_oom();
+
+                p = strdup("PROXY_ENABLED");
+                if (!p)
+                        return log_oom();
+
+                g_hash_table_replace(table, p, t);
+
+                steal_pointer(t);
+                steal_pointer(p);
         }
 
         return write_to_proxy_conf_file(table);

--- a/src/manager/network-manager.c
+++ b/src/manager/network-manager.c
@@ -2226,7 +2226,7 @@ int manager_configure_proxy(int enable,
                 if (!s)
                         return log_oom();
 
-                k = strdup("FTP_PROXY");
+                k = strdup("HTTPS_PROXY");
                 if (!k)
                         return log_oom();
 
@@ -2339,6 +2339,20 @@ int manager_configure_proxy(int enable,
         }
 
         return write_to_proxy_conf_file(table);
+}
+
+int manager_parse_proxy_config(GHashTable **c) {
+        _auto_cleanup_hash_ GHashTable *table = NULL;
+        int r;
+
+        assert(c);
+
+        r = parse_state_file("/etc/sysconfig/proxy", NULL, NULL, &table);
+        if (r < 0)
+                return r;
+
+        *c = steal_pointer(table);
+        return 0;
 }
 
 int manager_generate_network_config_from_yaml(const char *file) {

--- a/src/manager/network-manager.h
+++ b/src/manager/network-manager.h
@@ -149,5 +149,6 @@ int manager_configure_proxy(int enable,
                             const char *socks5,
                             const char *no_proxy);
 
+int manager_parse_proxy_config(GHashTable **c);
 
 void set_json(bool k);

--- a/src/manager/network-manager.h
+++ b/src/manager/network-manager.h
@@ -140,7 +140,8 @@ int manager_edit_link_network_config(const IfNameIndex *ifnameidx);
 
 int manager_remove_netdev(const IfNameIndex *ifnameidx, const char *kind);
 
-int manager_configure_proxy(const char *http,
+int manager_configure_proxy(int enable,
+                            const char *http,
                             const char *https,
                             const char *ftp,
                             const char *gopher,


### PR DESCRIPTION
```
build/nmctl show-proxy
Proxy Settings 
      Enabled: "no"
         HTTP: ""
        HTTPS: ""
          FTP: ""
       Gopher: ""
        Socks: ""
Socks5 Server: ""
     No Proxy: "localhost, 127.0.0.1"

```