### PR TITLE
nmctl: fixed version string

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('network-config-manager', 'c',
-        version : '1.0',
+        version : '0.4',
         license : 'Apache-2.0',
         default_options: [
                 'c_std=gnu99',


### PR DESCRIPTION
- `nmctl -v` giving wrong output
- Changed the version string to latest release