### PR TITLE
Treewide fix gcc warnings

### DIFF
--- a/src/dracut/dracut-parser.c
+++ b/src/dracut/dracut-parser.c
@@ -125,7 +125,7 @@ static int dracut_parse_mac(char *mac, Network *n) {
         _auto_cleanup_ IPAddress *peer = NULL, *prefix = NULL;
         _auto_cleanup_ Address *a = NULL;
         _auto_cleanup_strv_ char **s = NULL;
-        int r;
+        int r = 0;
 
         s = strsplit(line, ":", 9);
         if (!s)

--- a/src/lib-network/netlink/netlink.c
+++ b/src/lib-network/netlink/netlink.c
@@ -39,7 +39,7 @@ struct rtattr *rtnl_message_add_attribute_nested(struct nlmsghdr *hdr, int type,
 
         nest = NLMSG_TAIL(hdr);
 
-        r = rtnl_message_add_attribute(hdr, type, NULL, len);
+        r = rtnl_message_add_attribute(hdr, type, 0, len);
         if (r < 0)
                 return NULL;
 

--- a/src/manager/network-config-manager.c
+++ b/src/manager/network-config-manager.c
@@ -754,7 +754,7 @@ _public_ int ncm_link_get_dhcp_client_iaid(char *ifname, uint32_t *ret) {
 
 _public_ int ncm_link_set_network_section_bool(int argc, char *argv[]) {
         _auto_cleanup_ IfNameIndex *p = NULL;
-        const char *k;
+        const char *k = NULL;
         bool v;
         int r;
 
@@ -801,7 +801,7 @@ _public_ int ncm_link_set_network_section_bool(int argc, char *argv[]) {
 
 _public_ int ncm_link_set_dhcp4_section(int argc, char *argv[]) {
         _auto_cleanup_ IfNameIndex *p = NULL;
-        const char *k;
+        const char *k = NULL;
         bool v;
         int r;
 
@@ -836,7 +836,7 @@ _public_ int ncm_link_set_dhcp4_section(int argc, char *argv[]) {
 
 _public_ int ncm_link_set_dhcp6_section(int argc, char *argv[]) {
         _auto_cleanup_ IfNameIndex *p = NULL;
-        const char *k;
+        const char *k = NULL;
         bool v;
         int r;
 
@@ -1828,10 +1828,10 @@ _public_ int ncm_link_remove_dhcpv4_server(int argc, char *argv[]) {
 _public_ int ncm_link_add_ipv6_router_advertisement(int argc, char *argv[]) {
         uint32_t pref_lifetime = 0, valid_lifetime = 0, route_lifetime = 0, dns_lifetime = 0;
         _auto_cleanup_ IPAddress *prefix = NULL, *dns = NULL, *route_prefix = NULL;
-        int emit_dns = -1, emit_domain, assign = -1, managed = -1, other = -1;
+        int emit_dns = -1, emit_domain = -1, assign = -1, managed = -1, other = -1;
+        IPv6RAPreference preference = _IPV6_RA_PREFERENCE_INVALID;
         _auto_cleanup_ IfNameIndex *p = NULL;
         _auto_cleanup_ char *domain = NULL;
-        IPv6RAPreference preference;
         int r;
 
         r = parse_ifname_or_index(argv[1], &p);
@@ -2912,7 +2912,7 @@ _public_ int ncm_create_vlan(int argc, char *argv[]) {
         _auto_cleanup_ IfNameIndex *p = NULL;
         _auto_cleanup_ char *proto = NULL;
         uint16_t id;
-        int r, i;
+        int r = 0, i;
 
         for (i = 1; i < argc; i++) {
                 if (string_equal(argv[i], "dev") || string_equal(argv[i], "device") || string_equal(argv[i], "link")) {

--- a/src/share/network-util.c
+++ b/src/share/network-util.c
@@ -115,7 +115,7 @@ int parse_ipv4(const char *s, IPAddress **ret) {
         if (inet_pton(AF_INET, s, &buffer) <= 0)
                 return errno > 0 ? -errno : -EINVAL;
 
-        memcpy(&b->in, &buffer, sizeof(IPAddress));
+        memcpy(&b->in, &buffer, sizeof(struct in_addr));
         b->family = AF_INET;
 
         *ret = steal_pointer(b);
@@ -137,7 +137,7 @@ int parse_ipv6(const char *s, IPAddress **ret) {
         if (inet_pton(AF_INET6, s, &buffer) <= 0)
                 return errno > 0 ? -errno : -EINVAL;
 
-        memcpy(&b->in6, &buffer, sizeof(IPAddress));
+        memcpy(&b->in6, &buffer, sizeof(struct in6_addr));
         b->family = AF_INET6;
 
         *ret = steal_pointer(b);


### PR DESCRIPTION
```
../src/manager/network-config-manager.c: In function 'ncm_link_set_network_section_bool':
../src/manager/network-config-manager.c:799:16: warning: 'k' may be used uninitialized in this function [-Wmaybe-uninitialized]
  799 |         return manager_set_network_section_bool(p, k, v);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/manager/network-config-manager.c: In function 'ncm_link_set_dhcp4_section':
../src/manager/network-config-manager.c:834:16: warning: 'k' may be used uninitialized in this function [-Wmaybe-uninitialized]
  834 |         return manager_set_dhcp_section(p, k, v, true);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/manager/network-config-manager.c: In function 'ncm_link_set_dhcp6_section':
../src/manager/network-config-manager.c:861:16: warning: 'k' may be used uninitialized in this function [-Wmaybe-uninitialized]
  861 |         return manager_set_dhcp_section(p, k, v, false);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/manager/network-config-manager.c: In function 'ncm_link_add_ipv6_router_advertisement':
../src/manager/network-config-manager.c:2035:13: warning: 'preference' may be used uninitialized in this function [-Wmaybe-uninitialized]
 2035 |         r = manager_configure_ipv6_router_advertisement(p, prefix, route_prefix, dns, domain, pref_lifetime, valid_lifetime,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2036 |                                                         dns_lifetime, route_lifetime, preference, managed, other, emit_dns, emit_domain, assign);
      |                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/manager/network-config-manager.c:2035:13: warning: 'emit_domain' may be used uninitialized in this function [-Wmaybe-uninitialized]
../src/manager/network-config-manager.c: In function 'ncm_create_vlan':
../src/manager/network-config-manager.c:2915:13: warning: 'r' may be used uninitialized in this function [-Wmaybe-uninitialized]
 2915 |         int r, i;

../src/share/network-util.c: In function 'parse_ipv4':
../src/share/network-util.c:119:9: warning: 'memcpy' forming offset [4, 27] is out of the bounds [0, 4] of object 'buffer' with type 'struct in_addr' [-Warray-bounds]
  119 |         memcpy(&b->in, &buffer, sizeof(IPAddress));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/share/network-util.c:107:24: note: 'buffer' declared here
  107 |         struct in_addr buffer;
      |                        ^~~~~~
../src/share/network-util.c: In function 'parse_ipv6':
../src/share/network-util.c:141:9: warning: 'memcpy' forming offset [28, 31] is out of the bounds [0, 28] [-Warray-bounds]
  141 |         memcpy(&b->in6, &buffer, sizeof(IPAddress));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```