### PR TITLE
fix crash on json context

### DIFF
--- a/src/json/network-json.c
+++ b/src/json/network-json.c
@@ -574,8 +574,8 @@ int json_fill_system_status(char **ret) {
                 steal_ptr(j);
         }
 
-        (void) network_parse_ntp(&ntp);
-        if (ntp) {
+        r = network_parse_ntp(&ntp);
+        if (r >= 0 && ntp) {
                 _cleanup_(json_object_putp) json_object *ja = json_object_new_array();
                 char **d;
 

--- a/src/json/network-link-json.c
+++ b/src/json/network-link-json.c
@@ -199,7 +199,6 @@ static int json_fill_ipv6_link_local_addresses(Link *l, Addresses *addr, json_ob
         return 0;
 }
 
-
 static int json_fill_one_link_addresses(bool ipv4, Link *l, Addresses *addr, json_object *ret) {
         _cleanup_(json_object_putp) json_object *js = NULL, *jobj = NULL;
         GHashTableIter iter;
@@ -334,7 +333,7 @@ static int json_fill_one_link_addresses(bool ipv4, Link *l, Addresses *addr, jso
                 } else {
                         _auto_cleanup_ char *network = NULL;
 
-                        r = parse_network_file(l->ifindex, NULL, &network);
+                        r = parse_network_file(l->ifindex, l->name, &network);
                         if (r >= 0) {
                                 if (config_exists(network, "Network", "Address", c) || config_exists(network, "Address", "Address", c)) {
                                         js = json_object_new_string("static");
@@ -648,7 +647,7 @@ static int json_fill_one_link_routes(bool ipv4, Link *l, Routes *rts, json_objec
                         } else {
                                 _auto_cleanup_ char *network = NULL;
 
-                                r = parse_network_file(l->ifindex, NULL, &network);
+                                r = parse_network_file(l->ifindex, l->name, &network);
                                 if (r >= 0) {
                                         if (config_exists(network, "Network", "Gateway", c) || config_exists(network, "Route", "Gateway", c)) {
                                                 js = json_object_new_string("static");

--- a/src/manager/ctl-display.c
+++ b/src/manager/ctl-display.c
@@ -613,7 +613,7 @@ static int list_one_link(char *argv[]) {
                         if (router && c && string_has_prefix(c, router))
                                 printf("(dhcp) \n");
                         else {
-                                r = parse_network_file(p->ifindex, NULL, &network);
+                                r = parse_network_file(p->ifindex, p->ifname, &network);
                                 if (r >= 0) {
                                         if (config_exists(network, "Network", "Gateway", c) || config_exists(network, "Route", "Gateway", c))
                                                 printf("(static) \n");
@@ -1020,7 +1020,7 @@ _public_ int ncm_system_ipv4_status(int argc, char *argv[]) {
                  _auto_cleanup_ char *network = NULL;
                 bool first = true;
 
-                (void) parse_network_file(p->ifindex, NULL, &network);
+                (void) parse_network_file(p->ifindex, p->ifname, &network);
 
                 r = set_new(&devs, g_int64_hash, g_int64_equal);
                 if (r < 0)


### PR DESCRIPTION
```
(gdb) bt
#0  0x00007ffff78ad041 in raise () at /lib/libc.so.6
#1  0x00007ffff7896536 in abort () at /lib/libc.so.6
#2  0x00007ffff789641f in _nl_load_domain.cold () at /lib/libc.so.6
#3  0x00007ffff78a5852 in  () at /lib/libc.so.6
#4  0x00000000004539af in determine_conf_file_name (ifname=0x0, ret=0x7fffffffd960) at ../src/share/config-file.c:846
#5  0x0000000000449af0 in determine_network_conf_file (ifname=0x0, ret=0x7fffffffd9c8) at ../src/manager/network.c:466
#6  0x0000000000449d53 in parse_network_file (ifindex=1, ifname=0x0, ret=0x7fffffffda90) at ../src/manager/network.c:517
#7  0x0000000000410649 in json_fill_one_link_addresses (ipv4=false, l=0x4a3930, addr=0x4a5a50, ret=0x4a8530) at ../src/json/network-link-json.c:337
#8  0x0000000000416612 in json_fill_one_link (p=0x4a2ab0, ipv4=false, ret=0x7fffffffdd08) at ../src/json/network-link-json.c:1811
#9  0x000000000040dc25 in json_fill_system_status (ret=0x0) at ../src/json/network-json.c:498
#10 0x000000000041a009 in ncm_system_status (argc=1, argv=0x7fffffffe1b8) at ../src/manager/ctl-display.c:773
#11 0x0000000000407587 in ctl_run_command (m=0x4a0e30, argc=2, argv=0x7fffffffe1b8) at ../src/ctl/ctl.c:79
#12 0x000000000046bee1 in cli_run (argc=2, argv=0x7fffffffe1a8) at ../src/manager/network-manager-ctl.c:490
#13 0x000000000046bf3f in main (argc=2, argv=0x7fffffffe1a8) at ../src/manager/network-manager-ctl.c:496
(gdb) f 7
```