### PR TITLE
Fix return code of ncm_get_dns_mode

### DIFF
--- a/src/manager/network-config-manager.c
+++ b/src/manager/network-config-manager.c
@@ -2538,12 +2538,12 @@ _public_ int ncm_get_dns_mode(int argc, char *argv[]) {
         r = manager_get_link_dhcp_client(p, &mode);
         if (r >= 0)
                 printf("dhcp\n");
-        else {
-                if (manager_is_link_static_address(p))
-                        printf("static\n");
-        }
+        else if (manager_is_link_static_address(p))
+                printf("static\n");
+        else
+                return -ENOENT;
 
-        return -ENOENT;
+        return 0;
 }
 
 _public_ int ncm_show_dns_server(int argc, char *argv[]) {


### PR DESCRIPTION
After determining and printing either dhcp/static mode, return code should be 0.