### PR TITLE
nmctl: Adding json output for given interface name

### DIFF
--- a/src/json/network-json.h
+++ b/src/json/network-json.h
@@ -20,6 +20,9 @@ int json_fill_one_link(IfNameIndex *p, bool ipv4, json_object *jn, json_object *
 int json_fill_dns_server(const IfNameIndex *p, char **dns_config, int ifindex, json_object *jn);
 int json_fill_dns_server_domains(void);
 
+int json_get_link_address(IfNameIndex *p, char **ret);
+int json_fill_address(bool ipv4, Link *l, json_object *jn,  json_object *jobj);
+
 int address_flags_to_string(Address *a, json_object *jobj, uint32_t flags);
 int routes_flags_to_string(Route *rt, json_object *jobj, uint32_t flags);
 

--- a/src/manager/ctl-display.c
+++ b/src/manager/ctl-display.c
@@ -282,6 +282,10 @@ _public_ int ncm_display_one_link_addresses(int argc, char *argv[]) {
                 }
         }
 
+        if (arg_json)
+                return json_get_link_address(p, NULL);
+
+
         if (argc >= 2) {
                 for (int i = 2; i < argc; i++) {
                         if (str_eq(argv[i], "family") || str_eq(argv[i], "f")) {


### PR DESCRIPTION
nmctl show-addr dev <device> is showing the address in display format nmctl show-addr dev <device> -j will show address information for given device name in json format