### PR TITLE
display: Fixing the difference for show-dns-mode command

### DIFF
--- a/src/manager/network-config-manager.c
+++ b/src/manager/network-config-manager.c
@@ -2584,7 +2584,7 @@ _public_ int ncm_get_dns_mode(int argc, char *argv[]) {
         if (json_enabled())
                 return json_get_dns_mode(mode, dhcpv4, dhcpv6, static_dns);
 
-        display(beautify_enabled() ? true : false, ansi_color_bold_blue(),"DNS Mode: ");
+        display(beautify_enabled() ? true : false, ansi_color_bold_blue(),"DNSMode: ");
 
         if ((dhcpv4 || dhcpv6) && static_dns)
                 printf("merged\n");


### PR DESCRIPTION
nmctl show-dns-mode dev <device>
output: DNS Mode: DHCP

fixed output: DNSMode: DHCP

As json format is showing same way