### PR TITLE
nmctl: Fixed DHCP set/reset for IPV4.

### DIFF
--- a/tests/network-config-manager-tests.py
+++ b/tests/network-config-manager-tests.py
@@ -1391,6 +1391,20 @@ class TestCLINetwork:
         assert(parser.get('Address', 'DuplicateAddressDetection') == 'ipv4')
         assert(parser.get('Address', 'Label') == 'test')
 
+    def test_cli_set_ipv4(self):
+        assert(link_exist('test99') == True);
+
+        subprocess.check_call("nmctl set-ipv4 dev test99 gw 192.168.1.1 addr 192.168.1.34 dhcp no", shell = True)
+
+        assert(unit_exist('10-test99.network') == True)
+        parser = configparser.ConfigParser()
+        parser.read(os.path.join(networkd_unit_file_path, '10-test99.network'))
+
+        assert(parser.get('Match', 'Name') == 'test99')
+        assert(parser.get('Network', 'DHCP') == 'no')
+        assert(parser.get('Address', 'Address') == '192.168.1.34')
+        assert(parser.get('Route', 'Gateway') == '192.168.1.1')
+
     def test_cli_set_default_gateway(self):
         assert(link_exist('test99') == True)
 


### PR DESCRIPTION
Issue: nmctl set-ipv4 dhcp no is also reset dhcp for ipv6 like DHCP=yes convert to DHCP=no instead of DHCP=ipv6

Also while setting nmctl set-ipv4 dhcp yes it convert DHCP=yes to DHCP=ipv4.

Fix: Check for existing DHCP=mode, based on that only tune the DHCP configuration for ipv4 without affecting DHCP IPV6 status.