### PR TITLE
set_ipv6: Adding option to set static addresses and gateway using set…

### DIFF
--- a/src/manager/network-manager-ctl.c
+++ b/src/manager/network-manager-ctl.c
@@ -218,7 +218,7 @@ static int help(void) {
                "  remove-ipv6ra                dev [DEVICE] Removes Ipv6 Router Advertisement.\n"
                "  enable-ipv6                  dev [DEVICE] [BOOLEAN] Enable or disables IPv6 on the link.\n"
                "  set-ipv4                     dev [DEVICE] addr [ADDRESS] gw [GATEWAY ADDRESS] dhcp [BOOLEAN] keep [BOOLEAN] Configures device IPv4.\n"
-               "  set-ipv6                     dev [DEVICE] accept-ra [BOOLEAN] dhcp [BOOLEAN] keep [BOOLEAN] Configures device IPv6.\n"
+               "  set-ipv6                     dev [DEVICE] accept-ra [BOOLEAN] dhcp [BOOLEAN] keep [BOOLEAN] address|a|addr [ADDRESS] many [ADDRESS1,ADDRESS2...] gw [GATEWAY] Configures device IPv6.\n"
                "  add-sr-iov                   dev [DEVICE] [vf INTEGER] [vlanid INTEGER] [qos INTEGER] [vlanproto STRING] [macspoofck BOOLEAN] [qrss BOOLEAN]"
                                                      "\n\t\t\t\t      [trust BOOLEAN] [linkstate BOOLEAN or STRING] [macaddr ADDRESS] Configures SR-IOV VirtualFunction, "
                                                      "\n\t\t\t\t      VLANId, QualityOfService, VLANProtocol, MACSpoofCheck, QueryReceiveSideScaling, Trust, LinkState, MACAddress \n"


### PR DESCRIPTION
…-ipv6 command.

Issue: Following are the issue related to this command.

Using this command not able to tune accept-ra, dhcp and add static address at once. Setting address with keep no option is also afecting other configuration like dns and ipv4.

Fix: Adding support to tune accept-ra, dhcp and static address at once. Also setting address and gateway always overwrite existing ipv6 addresses and gateway without afecting ipv4 address and gateway.