### PR TITLE
nmctl: Removing redundent code for multiple address configuration

### DIFF
--- a/src/manager/network-config-manager.c
+++ b/src/manager/network-config-manager.c
@@ -1344,61 +1344,13 @@ _public_ int ncm_link_add_address(int argc, char *argv[]) {
                         prefix_route = r;
                         continue;
                 } else if (streq_fold(argv[i], "many")) {
-                        _auto_cleanup_strv_ char **s = NULL;
-                        bool white_space = false;
-
                         parse_next_arg(argv, argc, i);
 
-                        if (strchr(argv[i], ',')) {
-                                char **d;
-
-                                s = strsplit(argv[i], ",", -1);
-                                if (!s) {
-                                        log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
-                                        return -EINVAL;
-                                }
-
-                                s = strv_remove(s, "");
-                                if (!s) {
-                                        log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
-                                        return -EINVAL;
-                                }
-
-                                strv_foreach(d, s) {
-                                        _auto_cleanup_ IPAddress *a = NULL;
-
-                                        r = parse_ip_from_str(*d, &a);
-                                        if (r < 0) {
-                                                log_warning("Failed to parse address: %s", *d);
-                                                return r;
-                                        }
-                                }
-
-                        } else {
-                                _auto_cleanup_strv_ char **t = NULL;
-                                char **d;
-
-                                r = argv_to_strv(argc - 4, argv + i, &t);
-                                if (r < 0) {
-                                        log_warning("Failed to parse address: %s", strerror(-r));
-                                        return r;
-                                }
-
-                                strv_foreach(d, t) {
-                                        _auto_cleanup_ IPAddress *a = NULL;
-
-                                        r = parse_ip_from_str(*d, &a);
-                                        if (r >= 0) {
-                                                strv_extend(&s, *d);
-                                                i++;
-                                        }
-                                }
-                                white_space = true;
+                        parse_address_many(argv, argc, &i, &many);
+                        if (r < 0) {
+                                log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
+                                return r;
                         }
-
-                        many = steal_ptr(s);
-                        if (white_space)
-                                i--;
                         continue;
                 }
 
@@ -1454,61 +1406,13 @@ _public_ int ncm_link_remove_address(int argc, char *argv[]) {
 
                       continue;
                 } else if (streq_fold(argv[i], "many")) {
-                        _auto_cleanup_strv_ char **s = NULL;
-                        bool white_space = false;
-
                         parse_next_arg(argv, argc, i);
 
-                        if (strchr(argv[i], ',')) {
-                                char **d;
-
-                                s = strsplit(argv[i], ",", -1);
-                                if (!s) {
-                                        log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
-                                        return -EINVAL;
-                                }
-
-                                s = strv_remove(s, "");
-                                if (!s) {
-                                        log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
-                                        return -EINVAL;
-                                }
-
-                                strv_foreach(d, s) {
-                                        _auto_cleanup_ IPAddress *a = NULL;
-
-                                        r = parse_ip_from_str(*d, &a);
-                                        if (r < 0) {
-                                                log_warning("Failed to parse address: %s", *d);
-                                                return r;
-                                        }
-                                }
-
-                        } else {
-                                _auto_cleanup_strv_ char **t = NULL;
-                                char **d;
-
-                                r = argv_to_strv(argc - 4, argv + i, &t);
-                                if (r < 0) {
-                                        log_warning("Failed to parse address: %s", strerror(-r));
-                                        return r;
-                                }
-
-                                strv_foreach(d, t) {
-                                        _auto_cleanup_ IPAddress *a = NULL;
-
-                                        r = parse_ip_from_str(*d, &a);
-                                        if (r >= 0) {
-                                                strv_extend(&s, *d);
-                                                i++;
-                                        }
-                                }
-                                white_space = true;
+                        parse_address_many(argv, argc, &i, &addrs);
+                        if (r < 0) {
+                                log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
+                                return r;
                         }
-
-                        addrs = steal_ptr(s);
-                        if (white_space)
-                                i--;
                         continue;
                 } else if(streq_fold(argv[i], "family") || streq_fold(argv[i], "f")) {
                         parse_next_arg(argv, argc, i);
@@ -1578,61 +1482,13 @@ _public_ int ncm_link_replace_address(int argc, char *argv[]) {
 
                       continue;
                 } else if (streq_fold(argv[i], "many")) {
-                        _auto_cleanup_strv_ char **s = NULL;
-                        bool white_space = false;
-
                         parse_next_arg(argv, argc, i);
 
-                        if (strchr(argv[i], ',')) {
-                                char **d;
-
-                                s = strsplit(argv[i], ",", -1);
-                                if (!s) {
-                                        log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
-                                        return -EINVAL;
-                                }
-
-                                s = strv_remove(s, "");
-                                if (!s) {
-                                        log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
-                                        return -EINVAL;
-                                }
-
-                                strv_foreach(d, s) {
-                                        _auto_cleanup_ IPAddress *a = NULL;
-
-                                        r = parse_ip_from_str(*d, &a);
-                                        if (r < 0) {
-                                                log_warning("Failed to parse address: %s", *d);
-                                                return r;
-                                        }
-                                }
-
-                        } else {
-                                _auto_cleanup_strv_ char **t = NULL;
-                                char **d;
-
-                                r = argv_to_strv(argc - 4, argv + i, &t);
-                                if (r < 0) {
-                                        log_warning("Failed to parse address: %s", strerror(-r));
-                                        return r;
-                                }
-
-                                strv_foreach(d, t) {
-                                        _auto_cleanup_ IPAddress *a = NULL;
-
-                                        r = parse_ip_from_str(*d, &a);
-                                        if (r >= 0) {
-                                                strv_extend(&s, *d);
-                                                i++;
-                                        }
-                                }
-                                white_space = true;
+                        parse_address_many(argv, argc, &i, &addrs);
+                        if (r < 0) {
+                                log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
+                                return r;
                         }
-
-                        addrs = steal_ptr(s);
-                        if (white_space)
-                                i--;
                         continue;
                 } else if(streq_fold(argv[i], "family") || streq_fold(argv[i], "f")) {
                         parse_next_arg(argv, argc, i);
@@ -4762,61 +4618,13 @@ _public_ int ncm_link_set_ipv6(int argc, char *argv[]) {
 
                       continue;
                 } else if (streq_fold(argv[i], "many")) {
-                        _auto_cleanup_strv_ char **s = NULL;
-                        bool white_space = false;
-
                         parse_next_arg(argv, argc, i);
 
-                        if (strchr(argv[i], ',')) {
-                                char **d;
-
-                                s = strsplit(argv[i], ",", -1);
-                                if (!s) {
-                                        log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
-                                        return -EINVAL;
-                                }
-
-                                s = strv_remove(s, "");
-                                if (!s) {
-                                        log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
-                                        return -EINVAL;
-                                }
-
-                                strv_foreach(d, s) {
-                                        _auto_cleanup_ IPAddress *a = NULL;
-
-                                        r = parse_ip_from_str(*d, &a);
-                                        if (r < 0) {
-                                                log_warning("Failed to parse address: %s", *d);
-                                                return r;
-                                        }
-                                }
-
-                        } else {
-                                _auto_cleanup_strv_ char **t = NULL;
-                                char **d;
-
-                                r = argv_to_strv(argc - 4, argv + i, &t);
-                                if (r < 0) {
-                                        log_warning("Failed to parse address: %s", strerror(-r));
-                                        return r;
-                                }
-
-                                strv_foreach(d, t) {
-                                        _auto_cleanup_ IPAddress *a = NULL;
-
-                                        r = parse_ip_from_str(*d, &a);
-                                        if (r >= 0) {
-                                                strv_extend(&s, *d);
-                                                i++;
-                                        }
-                                }
-                                white_space = true;
+                        parse_address_many(argv, argc, &i, &addrs);
+                        if (r < 0) {
+                                log_warning("Failed to parse many addresses '%s': %s", argv[i], strerror(EINVAL));
+                                return r;
                         }
-
-                        addrs = steal_ptr(s);
-                        if (white_space)
-                                i--;
                         continue;
                 } else if (streq_fold(argv[i], "keep")) {
                         parse_next_arg(argv, argc, i);

--- a/src/share/network-util.h
+++ b/src/share/network-util.h
@@ -109,3 +109,5 @@ int device_activation_policy_name_to_type(const char *name);
 
 const char *required_address_family_for_online_type_to_name(int id);
 int required_address_family_for_online_name_to_type(const char *name);
+
+int parse_address_many(char **argv, int argc, int *i, char ***ret);


### PR DESCRIPTION
used through out multiple API's like add-addr, remove-addr, replace-addr and set-ipv6.