### PR TITLE
network-config-manager: Fix incorrect IPv6 config source

### DIFF
--- a/src/json/network-json.c
+++ b/src/json/network-json.c
@@ -1157,21 +1157,21 @@ static int json_array_to_ip(const json_object *obj, const int family, const int 
                 }
         }
 
+        if (prefix > 0)
+                g_string_append_printf(v, "/%d", prefix);
+
         if (family == AF_INET6) {
                 _auto_cleanup_ IPAddress *addr = NULL;
                 int r;
 
-                r = parse_ipv6(v->str, &addr);
+                r = parse_ip_from_str(v->str, &addr);
                 if (r < 0)
                         return r;
 
-                r = ip_to_str(AF_INET6, addr, &ip);
+                r = ip_to_str_prefix(AF_INET6, addr, &ip);
                 if (r < 0)
                         return r;
         }
-
-        if (prefix > 0)
-                g_string_append_printf(v, "/%d", prefix);
 
         if (family == AF_INET6)
                 *ret = steal_ptr(ip);


### PR DESCRIPTION
Issue - nmctl status <device> -j is showing ConfigSource as foreign for all kind of address like static, dynamic and foreign.

Now on existing flow to get a link address info nmctl get the info from dbus and parse the info similar for address as well. While parsing the address from json object to ip, prefix length is not appended to address. Hence ip matching with address always failing for IPv6, cause of this ConfigSource always set to foreign regardless of address is static or dynamic.

Fix - Fixed in json_array_to_ip parsing to take care of prefix value as well while returning the ip address after parsing the json object.